### PR TITLE
Fix bug in utils.py

### DIFF
--- a/label_studio_converter/utils.py
+++ b/label_studio_converter/utils.py
@@ -163,7 +163,11 @@ def download(
     if is_local_file:
         filename, dir_path = url.split('/data/', 1)[-1].split('?d=')
         dir_path = str(urllib.parse.unquote(dir_path))
-        filepath = os.path.join(LOCAL_FILES_DOCUMENT_ROOT, dir_path)
+        try:
+            from django.conf import settings.LOCAL_FILES_DOCUMENT_ROOT
+            filepath = os.path.join(settings.LOCAL_FILES_DOCUMENT_ROOT, dir_path)
+        except:
+            filepath = os.path.join(LOCAL_FILES_DOCUMENT_ROOT, dir_path)
         if not os.path.exists(filepath):
             raise FileNotFoundError(filepath)
         if download_resources:


### PR DESCRIPTION
Uses `settings.LOCAL_FILE_DOCUMENT_ROOT` if it's available. Otherwise trying to export such a file won't work.